### PR TITLE
added configuration copy from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ Please review the [dependency configuration](/meta/main.yml) for more details
      - role: nephelaiio.heartbeat
 ```
 
+## Example Playbook with config file
+
+```
+- hosts: servers
+  vars:
+    heartbeat_package_state: latest
+    heartbeat_conf_file: ./my-heartbeat-config.yml
+  roles:
+     - role: nephelaiio.heartbeat
+```
+
 ## Testing
 
 Please make sure your environment has [docker](https://www.docker.com) installed in order to run role validation tests. Additional python dependencies are listed in the [requirements file](https://github.com/nephelaiio/ansible-role-requirements/blob/master/requirements.txt)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
   when:
     - heartbeat_conf is defined
     - heartbeat_conf_manage | bool
-  
+
 - name: copy heartbeat configuration file
   copy:
     src: "{{ heartbeat_conf_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,15 @@
   when:
     - heartbeat_conf is defined
     - heartbeat_conf_manage | bool
+  
+- name: copy heartbeat configuration file
+  copy:
+    src: "{{ heartbeat_conf_file }}"
+    dest: "{{ heartbeat_conf_path }}"
+  notify: restart heartbeat
+  when:
+    - heartbeat_conf_file is defined
+    - heartbeat_conf_manage | bool
 
 - name: manage heartbeat services
   service:


### PR DESCRIPTION
Hello,
I am using this ansible role to install Heartbeat on my servers and it's working great 👍 

I have more than 15 website to ping, so I find it easier to have the whole Heartbeat configuration in a separated single file, I have modified the role to copy the Heartbeat config file when it is defined and added an example to the documentation.

Let me know if that suits you.

Best regards, Pierre.